### PR TITLE
no targets specified as warning instead of error

### DIFF
--- a/scripts/pacman-key.sh.in
+++ b/scripts/pacman-key.sh.in
@@ -687,8 +687,8 @@ esac
 # check for targets where needed
 if (( (ADD || DELETE || EDIT || IMPORT || IMPORT_TRUSTDB ||
 		LSIGNKEY || RECEIVE || VERIFY) && $# == 0 )); then
-	error "$(gettext "No targets specified")"
-	exit 1
+	warning "$(gettext "No targets specified")"
+	exit 0
 fi
 
 (( ! INIT )) && check_keyring

--- a/src/pacman/database.c
+++ b/src/pacman/database.c
@@ -47,8 +47,8 @@ static int change_install_reason(alpm_list_t *targets)
 	alpm_pkgreason_t reason;
 
 	if(targets == NULL) {
-		pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-		return 1;
+		pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+		return 0;
 	}
 
 	if(config->flags & ALPM_TRANS_FLAG_ALLDEPS) { /* --asdeps */

--- a/src/pacman/files.c
+++ b/src/pacman/files.c
@@ -332,8 +332,8 @@ int pacman_files(alpm_list_t *targets)
 	}
 
 	if(targets == NULL && !config->op_s_sync) {
-		pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-		return 1;
+		pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+		return 0;
 	}
 
 	/* search for a file */

--- a/src/pacman/query.c
+++ b/src/pacman/query.c
@@ -435,8 +435,8 @@ int pacman_query(alpm_list_t *targets)
 	 * invalid: isfile, owns */
 	if(targets == NULL) {
 		if(config->op_q_isfile || config->op_q_owns) {
-			pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-			return 1;
+			pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+			return 0;
 		}
 
 		for(i = alpm_db_get_pkgcache(db_local); i; i = alpm_list_next(i)) {

--- a/src/pacman/remove.c
+++ b/src/pacman/remove.c
@@ -82,8 +82,8 @@ int pacman_remove(alpm_list_t *targets)
 	alpm_list_t *i, *data = NULL;
 
 	if(targets == NULL) {
-		pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-		return 1;
+		pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+		return 0;
 	}
 
 	/* Step 0: create a new transaction */

--- a/src/pacman/sync.c
+++ b/src/pacman/sync.c
@@ -950,8 +950,8 @@ int pacman_sync(alpm_list_t *targets)
 		} else {
 			/* don't proceed here unless we have an operation that doesn't require a
 			 * target list */
-			pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-			return 1;
+			pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+			return 0;
 		}
 	}
 

--- a/src/pacman/upgrade.c
+++ b/src/pacman/upgrade.c
@@ -73,8 +73,8 @@ int pacman_upgrade(alpm_list_t *targets)
 	alpm_list_t *i;
 
 	if(targets == NULL) {
-		pm_printf(ALPM_LOG_ERROR, _("no targets specified (use -h for help)\n"));
-		return 1;
+		pm_printf(ALPM_LOG_WARNING, _("no targets specified (use -h for help)\n"));
+		return 0;
 	}
 
 	/* carve out remote targets and move it into a separate list */


### PR DESCRIPTION
This came up on https://github.com/kewlfft/ansible-aur/pull/50

https://github.com/Jguer/yay does not produce an error if the argument list is empty.

As general arguments:

- empty is as 0 in mathematics
- empty avoids If-then-else in using software
- empty makes it easier to defer the decision to provide packages or not further up the stack without if-then-else

19 test cases failed before the change and after the change. Maybe that is the current state or due to my setup,
but without correlation to the change made.